### PR TITLE
mcu/nrf5340: Add trng to netcore. Use existing trng_nrf52 driver

### DIFF
--- a/hw/drivers/trng/trng_nrf52/src/trng_nrf52.c
+++ b/hw/drivers/trng/trng_nrf52/src/trng_nrf52.c
@@ -18,6 +18,7 @@
  */
 
 #include <string.h>
+#include "nrfx.h"
 #include "mcu/cmsis_nvic.h"
 #include "trng/trng.h"
 #include "trng_nrf52/trng_nrf52.h"

--- a/hw/mcu/nordic/nrf5340_net/pkg.yml
+++ b/hw/mcu/nordic/nrf5340_net/pkg.yml
@@ -46,5 +46,8 @@ pkg.deps.SPI_0_MASTER:
 pkg.deps.I2C_0':
     - "@apache-mynewt-core/hw/bus/drivers/i2c_nrf5340"
 
+pkg.deps.TRNG:
+    - "@apache-mynewt-core/hw/drivers/trng/trng_nrf52"
+
 pkg.deps.BLE_CONTROLLER:
     - "@apache-mynewt-nimble/nimble/drivers/nrf5340"

--- a/hw/mcu/nordic/nrf5340_net/src/nrf5340_net_periph.c
+++ b/hw/mcu/nordic/nrf5340_net/src/nrf5340_net_periph.c
@@ -39,6 +39,11 @@
 #include <bus/drivers/i2c_nrf5340.h>
 #endif
 
+#if MYNEWT_VAL(TRNG)
+#include "trng/trng.h"
+#include "trng_nrf52/trng_nrf52.h"
+#endif
+
 #if MYNEWT_VAL(UART_0)
 static struct uart_dev os_bsp_uart0;
 static const struct nrf5340_net_uart_cfg os_bsp_uart0_cfg = {
@@ -74,6 +79,10 @@ static const struct bus_i2c_dev_cfg i2c0_cfg = {
     .pin_scl = MYNEWT_VAL(I2C_0_PIN_SCL),
 };
 static struct bus_i2c_dev i2c0_bus;
+#endif
+
+#if MYNEWT_VAL(TRNG)
+static struct trng_dev os_bsp_trng;
 #endif
 
 static void
@@ -153,6 +162,21 @@ nrf5340_net_periph_create_i2c(void)
 #endif
 }
 
+static void
+nrf5340_net_periph_create_trng(void)
+{
+    int rc;
+
+    (void)rc;
+
+#if MYNEWT_VAL(TRNG)
+    rc = os_dev_create(&os_bsp_trng.dev, "trng",
+                       OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
+                       nrf52_trng_dev_init, NULL);
+    assert(rc == 0);
+#endif
+}
+
 void
 nrf5340_net_periph_create(void)
 {
@@ -160,4 +184,5 @@ nrf5340_net_periph_create(void)
     nrf5340_net_periph_create_uart();
     nrf5340_net_periph_create_spi();
     nrf5340_net_periph_create_i2c();
+    nrf5340_net_periph_create_trng();
 }


### PR DESCRIPTION
- Add nrfx header to trng_nrf52.c